### PR TITLE
ci(publish): remove docker hub publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         id: docker_metadata
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }},${{ github.repository }}
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }},value=nightly
             type=semver,pattern={{version}}
@@ -35,12 +35,6 @@ jobs:
           registry: ghcr.io
           username: ${{ secrets.DOCKER_REGISTRY_ID }}
           password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: okp4
-          password: ${{ secrets.DOCKER_HUB_REGISTRY_TOKEN }}
 
       - name: Build and publish image(s)
         uses: docker/build-push-action@v3


### PR DESCRIPTION
The repository being private for the moment, I propose to turn off the docker hub publication, we'll configure it when we'll go public.