### PR TITLE
ci: improve roles attribution

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,23 +10,26 @@ updates:
       - fredericvilcot
       - ErikssonJoakim
       - lolottetheclash
+      - JoeyDjr
     assignees:
       - ccamel
       - fredericvilcot
       - lolottetheclash
+      - JoeyDjr
     open-pull-requests-limit: 5
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
     reviewers:
-      - amimart
       - ccamel
       - fredericvilcot
       - ErikssonJoakim
       - lolottetheclash
+      - JoeyDjr
     assignees:
       - ccamel
       - fredericvilcot
       - lolottetheclash
+      - JoeyDjr
     open-pull-requests-limit: 5


### PR DESCRIPTION
These modifications aim to add @JoeyDjr  on the dependabot PR and to remove @amimart  from the npm notifications, as validated with @fredericvilcot .